### PR TITLE
Feature/allow bot user

### DIFF
--- a/otterdog/eclipse-xpanse.jsonnet
+++ b/otterdog/eclipse-xpanse.jsonnet
@@ -86,8 +86,8 @@ orgs.newOrg('eclipse-xpanse') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           bypass_pull_request_allowances+: [
-           "@eclipse-xpanse-bot"
-           ],
+            "@eclipse-xpanse-bot"
+          ],
           required_approving_review_count: 1,
           requires_status_checks: false,
           requires_strict_status_checks: true,
@@ -185,9 +185,9 @@ orgs.newOrg('eclipse-xpanse') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-        bypass_pull_request_allowances+: [
-          "@eclipse-xpanse-bot"
-        ],
+          bypass_pull_request_allowances+: [
+            "@eclipse-xpanse-bot"
+          ],
           required_approving_review_count: 0,
           requires_status_checks: false,
           requires_strict_status_checks: true,

--- a/otterdog/eclipse-xpanse.jsonnet
+++ b/otterdog/eclipse-xpanse.jsonnet
@@ -85,6 +85,9 @@ orgs.newOrg('eclipse-xpanse') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
+          bypass_pull_request_allowances+: [
+           "@eclipse-xpanse-bot"
+           ],
           required_approving_review_count: 1,
           requires_status_checks: false,
           requires_strict_status_checks: true,
@@ -182,6 +185,9 @@ orgs.newOrg('eclipse-xpanse') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
+        bypass_pull_request_allowances+: [
+          "@eclipse-xpanse-bot"
+        ],
           required_approving_review_count: 1,
           requires_status_checks: false,
           requires_strict_status_checks: true,

--- a/otterdog/eclipse-xpanse.jsonnet
+++ b/otterdog/eclipse-xpanse.jsonnet
@@ -188,7 +188,7 @@ orgs.newOrg('eclipse-xpanse') {
         bypass_pull_request_allowances+: [
           "@eclipse-xpanse-bot"
         ],
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
           requires_status_checks: false,
           requires_strict_status_checks: true,
         },


### PR DESCRIPTION
@netomi opened this PR with the assumption that the `BOT_GITHUB_DOCKER_TOKEN` token also belongs to `eclipse-xpanse-bot` user.

Additionally I have temporarily disabled our internal approval process just to test the job quickly, 